### PR TITLE
Improve dependency checks for flyer scripts

### DIFF
--- a/src/create_flyer.sh
+++ b/src/create_flyer.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Error: required command '$1' not found" >&2
+    exit 1
+  }
+}
+
+for cmd in jq node javascript-obfuscator html-minifier-terser; do
+  require_cmd "$cmd"
+done
 
 CONFIG_PATH="src/config.json"
 FROM_PDF=""
@@ -31,9 +42,6 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
-
-# Ensure jq is installed
-command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }
 
 # Helper function to update config
 update_config_interactive() {

--- a/src/obfuscate_index.sh
+++ b/src/obfuscate_index.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+set -euo pipefail
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Error: required command '$1' not found" >&2
+    exit 1
+  }
+}
+
+for cmd in javascript-obfuscator html-minifier-terser node; do
+  require_cmd "$cmd"
+done
+
 # Input and output file names
 input_file="index-master.html"
 output_file="index.html"

--- a/src/obfuscate_nostr.sh
+++ b/src/obfuscate_nostr.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+set -euo pipefail
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "Error: required command '$1' not found" >&2
+    exit 1
+  }
+}
+
+for cmd in javascript-obfuscator html-minifier-terser node; do
+  require_cmd "$cmd"
+done
+
 # Input and output file names
 input_file="nostr-master.html"
 output_file="nostr.html"


### PR DESCRIPTION
## Summary
- enforce `set -euo pipefail` on flyer helper scripts
- ensure required commands are present before continuing

## Testing
- `shellcheck src/create_flyer.sh src/obfuscate_index.sh src/obfuscate_nostr.sh`

------
https://chatgpt.com/codex/tasks/task_b_6851f36688e8832b9974beb08ffc5a75