### PR TITLE
Add dependency install docs and setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,25 @@ VoxVera provides scripts and templates for producing printable flyers with QR co
 - **javascript-obfuscator** and **html-minifier-terser** (installed via npm)
 - **pdftotext** (optional, used when extracting fields from a PDF form)
 
+## Installing Dependencies
+
+On Debian or Ubuntu systems you can install the required packages with:
+
+```bash
+sudo apt update
+sudo apt install -y jq qrencode imagemagick poppler-utils nodejs npm
+```
+
+The obfuscation scripts also rely on a pair of Node modules. Install them
+globally:
+
+```bash
+npm install -g javascript-obfuscator html-minifier-terser
+```
+
+A helper script `setup.sh` is provided to check for these dependencies and
+install anything that is missing.
+
 ## Generating a Flyer
 Run the helper script from the repository root:
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+set -e
+
+check_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+apt_packages=()
+
+if ! check_cmd jq; then
+  apt_packages+=(jq)
+fi
+
+if ! check_cmd qrencode; then
+  apt_packages+=(qrencode)
+fi
+
+if ! check_cmd convert; then
+  apt_packages+=(imagemagick)
+fi
+
+if ! check_cmd pdftotext; then
+  apt_packages+=(poppler-utils)
+fi
+
+if ! check_cmd node || ! check_cmd npm; then
+  apt_packages+=(nodejs npm)
+fi
+
+if [ ${#apt_packages[@]} -gt 0 ]; then
+  echo "Installing system packages: ${apt_packages[*]}"
+  sudo apt-get update
+  sudo apt-get install -y "${apt_packages[@]}"
+fi
+
+for pkg in javascript-obfuscator html-minifier-terser; do
+  if ! check_cmd "$pkg"; then
+    npm install -g "$pkg"
+  fi
+done
+
+echo "All dependencies are installed."

--- a/src/README.md
+++ b/src/README.md
@@ -26,17 +26,24 @@ This repository contains a simple Bash script to obfuscate and minify a single H
    npm -v
    ```
 
+### Install Additional Packages
+
+The helper scripts rely on a few system utilities:
+
+```bash
+sudo apt install -y jq qrencode imagemagick poppler-utils
+```
+
 ### Install Required Tools
 
-1. **Install Terser:**
-   ```bash
-   npm install -g terser
-   ```
+Install the Node-based tools used by the obfuscation scripts:
 
-2. **Install html-minifier-terser:**
-   ```bash
-   npm install -g html-minifier-terser
-   ```
+```bash
+npm install -g javascript-obfuscator html-minifier-terser
+```
+
+You can also run `../setup.sh` from the repository root to install all
+prerequisites automatically.
 
 ## Script Usage
 


### PR DESCRIPTION
## Summary
- document apt and npm install commands
- describe setup.sh helper
- add setup.sh script for checking/installing dependencies

## Testing
- `bash -n setup.sh`
- `./setup.sh`

------
https://chatgpt.com/codex/tasks/task_b_6851f7a88224832b8d0a5ebfd6572fbc