### PR TITLE
Update flyer docs for new QR code prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ Run the helper script from the repository root:
 ./src/create_flyer.sh --from-pdf path/to/form.pdf
 ```
 
+When run interactively you'll be prompted for details such as the flyer title
+and headline. The script now also asks for a **URL** and a **Tear-off link**.
+These values are written into `src/config.json` and determine the QR code
+targets.
+
 The script updates `src/config.json`, regenerates QR codes, obfuscates `index-master.html` and `nostr-master.html`, and copies the resulting files plus PDFs and QR images into `host/<subdomain>`. The contents in that directory can then be hosted.
 
 Additional documentation is available in the `src/` directory; see [src/README.md](src/README.md) for more details on the obfuscation scripts and additional usage notes.


### PR DESCRIPTION
## Summary
- describe URL and Tear-off link prompts when using `create_flyer.sh`
- note that these values drive the QR code targets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68520d4e1198832ba4cae1b8d0814a0d