### PR TITLE
Allow alternate config paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,16 +63,19 @@ Run the helper script from the repository root:
 # interactive prompts
 ./src/create_flyer.sh
 
+# use an alternate config file
+./src/create_flyer.sh -c path/to/custom.json
+
 # use answers from an existing PDF form
 ./src/create_flyer.sh --from-pdf path/to/form.pdf
 ```
 
 When run interactively you'll be prompted for details such as the flyer title
 and headline. The script now also asks for a **URL** and a **Tear-off link**.
-These values are written into `src/config.json` and determine the QR code
-targets.
+These values are written into the configuration file (`src/config.json` by
+default) and determine the QR code targets.
 
-The script updates `src/config.json`, regenerates QR codes, obfuscates `index-master.html` and `nostr-master.html`, and copies the resulting files plus PDFs and QR images into `host/<subdomain>`. The contents in that directory can then be hosted.
+The script updates the chosen config file, regenerates QR codes, obfuscates `index-master.html` and `nostr-master.html`, and copies the resulting files plus PDFs and QR images into `host/<subdomain>`. The contents in that directory can then be hosted.
 
 Additional documentation is available in the `src/` directory; see [src/README.md](src/README.md) for more details on the obfuscation scripts and additional usage notes.
 

--- a/src/README.md
+++ b/src/README.md
@@ -131,10 +131,13 @@ The `create_flyer.sh` script automates filling `config.json`, building the HTML 
 # interactive mode
 ./create_flyer.sh
 
+# use an alternate config file
+./create_flyer.sh -c path/to/custom.json
+
 # use an existing filled PDF form
 ./create_flyer.sh --from-pdf path/to/form.pdf
 ```
 
-By default the script updates `src/config.json`. After answering the prompts (or extracting from the PDF), `index.html` and `nostr.html` are generated and copied along with the QR code images and PDFs. The files end up in `host/<subdomain>` which can be served statically.
+By default the script updates `src/config.json`. Use the `-c` option to specify a different file. After answering the prompts (or extracting from the PDF), `index.html` and `nostr.html` are generated and copied along with the QR code images and PDFs. The files end up in `host/<subdomain>` which can be served statically.
 
 QR codes are built automatically during this process. After the configuration is updated, `create_flyer.sh` calls `generate_qr.sh` to read the URLs from `config.json` and produce `qrcode-content.png` and `qrcode-tear-offs.png`.

--- a/src/create_flyer.sh
+++ b/src/create_flyer.sh
@@ -48,6 +48,9 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# convert CONFIG_PATH to absolute path for nested scripts
+CONFIG_PATH="$(realpath "$CONFIG_PATH")"
+
 # Helper function to update config
 update_config_interactive() {
   read -rp "Name: " name
@@ -102,11 +105,12 @@ if [[ $NON_INTERACTIVE -eq 0 ]]; then
   fi
 fi
 
+
 # Regenerate QR codes based on the updated configuration
-( cd src && ./generate_qr.sh )
+( cd src && ./generate_qr.sh "$CONFIG_PATH" )
 
 # Run obfuscation scripts
-( cd src && ./obfuscate_index.sh && ./obfuscate_nostr.sh )
+( cd src && ./obfuscate_index.sh "$CONFIG_PATH" && ./obfuscate_nostr.sh "$CONFIG_PATH" )
 
 subdomain=$(jq -r '.subdomain' "$CONFIG_PATH")
 DEST="host/${subdomain}"

--- a/src/generate_qr.sh
+++ b/src/generate_qr.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-CONFIG="config.json"
+CONFIG="${1:-config.json}"
 
 # Ensure dependencies
 command -v jq >/dev/null 2>&1 || { echo "jq is required" >&2; exit 1; }

--- a/src/obfuscate_index.sh
+++ b/src/obfuscate_index.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+CONFIG_PATH="${1:-config.json}"
+
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || {
     echo "Error: required command '$1' not found" >&2

--- a/src/obfuscate_nostr.sh
+++ b/src/obfuscate_nostr.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+CONFIG_PATH="${1:-config.json}"
+
 require_cmd() {
   command -v "$1" >/dev/null 2>&1 || {
     echo "Error: required command '$1' not found" >&2


### PR DESCRIPTION
## Summary
- allow scripts to accept custom config path
- pass the selected config path from `create_flyer.sh`
- document `-c` option in README files

## Testing
- `bash -n src/generate_qr.sh`
- `bash -n src/obfuscate_index.sh`
- `bash -n src/obfuscate_nostr.sh`
- `bash -n src/create_flyer.sh`
- `./src/create_flyer.sh --help` *(fails: required command `javascript-obfuscator` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685211a5c06c832b8c27ff19514c72fe