### PR TITLE
Fix newline handling in create_flyer.sh

### DIFF
--- a/src/create_flyer.sh
+++ b/src/create_flyer.sh
@@ -62,7 +62,7 @@ update_config_interactive() {
   content=""
   while IFS= read -r line; do
     [[ "$line" == "EOF" ]] && break
-    content+="$line\n"
+    content+="$line"$'\n'
   done
   read -rp "URL message: " url_message
 


### PR DESCRIPTION
## Summary
- ensure content collected interactively uses real newline characters

## Testing
- `npm install -g javascript-obfuscator html-minifier-terser`
- `apt-get install -y qrencode imagemagick bsdmainutils`
- `./src/create_flyer.sh` (manual input)


------
https://chatgpt.com/codex/tasks/task_b_68521814c3b0832b819bba4e1ea34930