### PR TITLE
Add OnionShare hosting script

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,20 +100,20 @@ Each JSON file is copied to `src/config.json` and processed with
 `create_flyer.sh --no-interaction`. Existing folders under `host/` with the
 same subdomain are removed before new files are written.
 
-## Hosting Options
-The folder under `host/<subdomain>` contains all of the files needed to serve
-the flyer as a static website. A few easy ways to make it publicly accessible
-include:
+## Hosting with OnionShare
+The folder under `host/<subdomain>` contains everything needed to serve the
+flyer. Run the helper script `serve_with_onionshare.sh` from the repository
+root to publish it over Tor:
 
-- **GitHub Pages** – Create a new repository or use GitHub Pages from this one
-  and push the contents of `host/<subdomain>` to a branch called `gh-pages`.
-- **Netlify** – Drag and drop the folder onto Netlify or connect it to a Git
-  repository. Netlify will automatically deploy the static files and provide a
-  public URL.
-- **OnionShare** – For a privacy‑focused option, you can host the folder from
-  an old laptop running [OnionShare](https://onionshare.org). OnionShare shares
-  the files over Tor, allowing others to access them using the provided onion
-  address.
+```bash
+./serve_with_onionshare.sh
+```
+
+The script launches `onionshare-cli` in persistent website mode, waits for the
+generated onion URL, patches `config.json`, regenerates the QR codes and
+obfuscated HTML, and then copies the updated files back into the `host`
+directory. The onion address is printed when ready. Keep OnionShare running to
+continue hosting.
 
 `index.html` fetches `config.json` dynamically, so the flyer should be viewed
 through a local or remote web server. For quick testing, run

--- a/serve_with_onionshare.sh
+++ b/serve_with_onionshare.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+CONFIG="src/config.json"
+if [[ $# -gt 0 ]]; then
+  CONFIG="$1"
+fi
+
+# get subdomain from config
+subdomain=$(jq -r '.subdomain' "$CONFIG")
+DIR="host/${subdomain}"
+if [[ ! -d "$DIR" ]]; then
+  echo "Directory $DIR not found" >&2
+  exit 1
+fi
+
+logfile="$DIR/onionshare.log"
+
+# start OnionShare in background
+onionshare-cli --website --public --persistent "$DIR/.onionshare-session" "$DIR" >"$logfile" 2>&1 &
+os_pid=$!
+
+# wait for onion address to appear
+while ! grep -m1 -Eo 'https?://[a-z0-9]+\.onion' "$logfile" >/dev/null; do
+  sleep 1
+  if ! kill -0 $os_pid 2>/dev/null; then
+    echo "OnionShare exited unexpectedly" >&2
+    cat "$logfile" >&2
+    exit 1
+  fi
+done
+
+onion_url=$(grep -m1 -Eo 'https?://[a-z0-9]+\.onion' "$logfile")
+
+# update config with onion url
+jq --arg url "$onion_url" '.url=$url | .tear_off_link=$url' "$DIR/config.json" >"$DIR/config.tmp" && mv "$DIR/config.tmp" "$DIR/config.json"
+
+# regenerate assets
+(cd src && ./generate_qr.sh "$DIR/config.json")
+(cd src && ./obfuscate_index.sh "$DIR/config.json" && ./obfuscate_nostr.sh "$DIR/config.json")
+cp src/index.html src/nostr.html src/qrcode-content.png src/qrcode-tear-offs.png "$DIR/"
+
+echo "Onion URL: $onion_url"
+
+echo "OnionShare running (PID $os_pid). See $logfile for details."


### PR DESCRIPTION
## Summary
- add `serve_with_onionshare.sh` for OnionShare hosting
- update README to describe Tor hosting as primary method

## Testing
- `onionshare-cli --help | head -n 20`
- `apt-get install -y onionshare-cli >/tmp/apt.onionshare && tail -n 20 /tmp/apt.onionshare`


------
https://chatgpt.com/codex/tasks/task_b_685368c15cf0832b9e7a03b630c0cee8