### PR TITLE
Add cross-platform install scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,22 @@
 
 VoxVera provides scripts and templates for producing printable flyers with QR codes. These flyers link to content hosted through Tor and can also include a Nostr page. The project automates building the HTML, generating the QR codes, and copying all assets into a directory under `host/` so they can be served statically.
 
+## Quick Install
+
+Run the installer to set up all dependencies and the `voxvera` CLI in one step.
+
+### Linux/macOS
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/PR0M3TH3AN/VoxVera/main/install.sh | bash
+```
+
+### Windows PowerShell
+
+```powershell
+irm https://raw.githubusercontent.com/PR0M3TH3AN/VoxVera/main/install.ps1 | iex
+```
+
 ## Prerequisites
 - **Node.js** and **npm**
 - **jq**

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,35 @@
+$ErrorActionPreference = 'Stop'
+
+$packages = @('tor', 'onionshare', 'jq', 'qrencode', 'imagemagick')
+
+function Install-Choco {
+    param([string]$Name)
+    if (-not (Get-Package -Name $Name -ErrorAction SilentlyContinue)) {
+        choco install $Name -y
+    }
+}
+
+function Install-Pkg {
+    param([string]$Name)
+    if (-not (Get-Package -Name $Name -ErrorAction SilentlyContinue)) {
+        Install-Package -Name $Name -Force -ErrorAction Stop
+    }
+}
+
+$choco = Get-Command choco -ErrorAction SilentlyContinue
+if ($choco) {
+    foreach ($p in $packages) { Install-Choco $p }
+} else {
+    foreach ($p in $packages) { Install-Pkg $p }
+}
+
+if (Get-Command pipx -ErrorAction SilentlyContinue) {
+    pipx install voxvera --force
+} else {
+    $dest = "$HOME/.local/bin"
+    New-Item -ItemType Directory -Path $dest -Force | Out-Null
+    $url = 'https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera.exe'
+    Invoke-WebRequest -Uri $url -OutFile "$dest/voxvera.exe"
+}
+
+Write-Host 'VoxVera installed successfully.'

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -e
+
+command_exists() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Detect package manager
+if command_exists apt-get; then
+  PM="apt"
+elif command_exists dnf; then
+  PM="dnf"
+elif command_exists yum; then
+  PM="yum"
+elif command_exists pacman; then
+  PM="pacman"
+elif command_exists brew; then
+  PM="brew"
+elif command_exists apk; then
+  PM="apk"
+else
+  echo "Unsupported system: could not detect package manager" >&2
+  exit 1
+fi
+
+install_pkg() {
+  case "$PM" in
+    apt)
+      sudo apt-get update
+      sudo apt-get install -y "$@"
+      ;;
+    dnf)
+      sudo dnf install -y "$@"
+      ;;
+    yum)
+      sudo yum install -y "$@"
+      ;;
+    pacman)
+      sudo pacman -Sy --noconfirm "$@"
+      ;;
+    brew)
+      brew install "$@"
+      ;;
+    apk)
+      sudo apk add --no-cache "$@"
+      ;;
+  esac
+}
+
+require_pkg() {
+  local cmd=$1
+  local pkg=$2
+  if ! command_exists "$cmd"; then
+    install_pkg "$pkg"
+  fi
+}
+
+require_pkg tor tor
+require_pkg onionshare-cli onionshare-cli
+require_pkg jq jq
+require_pkg qrencode qrencode
+require_pkg convert imagemagick
+
+if command_exists pipx; then
+  pipx install --force voxvera
+else
+  install_dir="$HOME/.local/bin"
+  mkdir -p "$install_dir"
+  url="https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera"
+  dest="$install_dir/voxvera"
+  if command_exists curl; then
+    curl -fsSL "$url" -o "$dest"
+  elif command_exists wget; then
+    wget -q "$url" -O "$dest"
+  else
+    echo "Install curl or wget to download voxvera" >&2
+    exit 1
+  fi
+  chmod +x "$dest"
+fi
+
+echo "VoxVera installed successfully."


### PR DESCRIPTION
## Summary
- add install.sh script for Linux/macOS
- add install.ps1 script for Windows
- document one-line installers in README

## Testing
- `bash -n install.sh`

------
https://chatgpt.com/codex/tasks/task_b_685375afc320832b882b2ea4db2db0e0