### PR TITLE
Add Dockerfile and dev container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,8 @@
+{
+  "name": "VoxVera",
+  "build": {
+    "dockerfile": "../Dockerfile",
+    "context": ".."
+  },
+  "workspaceFolder": "/workspace/VoxVera"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    tor onionshare-cli \
+    jq qrencode imagemagick poppler-utils \
+    nodejs npm \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install npm tools for HTML/JS processing
+RUN npm install -g javascript-obfuscator html-minifier-terser
+
+# Copy VoxVera source
+COPY . /opt/voxvera
+ENV PYTHONPATH=/opt/voxvera
+
+# Make voxvera command available
+RUN echo '#!/bin/sh\nexec python3 -m voxvera.cli "$@"' > /usr/local/bin/voxvera \
+    && chmod +x /usr/local/bin/voxvera
+
+# Prepare flyers volume
+RUN mkdir /flyers && ln -s /flyers /opt/voxvera/host
+VOLUME /flyers
+WORKDIR /opt/voxvera
+
+CMD ["voxvera", "quickstart"]

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -1,0 +1,16 @@
+# Docker Usage
+
+A prebuilt image containing Tor, OnionShare and the `voxvera` CLI is published to
+`ghcr.io/voxvera/voxvera`.
+
+```bash
+# pull the image
+docker pull ghcr.io/voxvera/voxvera:latest
+
+# run voxvera quickstart with flyers stored in ./flyers
+mkdir -p flyers
+docker run -it --rm -v "$(pwd)/flyers:/flyers" ghcr.io/voxvera/voxvera
+```
+
+The container uses `/flyers` as the working directory and runs `voxvera quickstart`
+by default. All generated flyer files will appear in the mounted `flyers` folder.


### PR DESCRIPTION
## Summary
- add Dockerfile to package Tor, OnionShare and VoxVera CLI
- expose `/flyers` volume and default command
- document image usage in `docs/docker.md`
- add devcontainer file pointing to the Dockerfile

## Testing
- `docker build` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_b_685376674a14832ba4e649cf771d4b19