### PR TITLE
Improve voxvera init workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ irm https://raw.githubusercontent.com/PR0M3TH3AN/VoxVera/main/install.ps1 | iex
 - **ImageMagick** (`convert`)
 - **javascript-obfuscator** and **html-minifier-terser** (installed via npm)
 - **pdftotext** (optional, used when extracting fields from a PDF form)
+- **Python packages** [`InquirerPy`](https://github.com/kazhala/InquirerPy) and [`rich`](https://github.com/Textualize/rich)
 
 ## Installing Dependencies
 
@@ -53,6 +54,12 @@ globally:
 
 ```bash
 npm install -g javascript-obfuscator html-minifier-terser
+```
+
+Install the Python dependencies:
+
+```bash
+pip install --user InquirerPy rich
 ```
 
 A helper script `setup.sh` is provided to check for these dependencies and

--- a/setup.sh
+++ b/setup.sh
@@ -39,4 +39,15 @@ for pkg in javascript-obfuscator html-minifier-terser; do
   fi
 done
 
+# ensure Python packages used by the CLI are available
+for py in InquirerPy rich; do
+  python3 - <<EOF >/dev/null 2>&1
+import importlib.util, sys
+sys.exit(0 if importlib.util.find_spec('$py') else 1)
+EOF
+  if [ $? -ne 0 ]; then
+    pip install --user "$py"
+  fi
+done
+
 echo "All dependencies are installed."


### PR DESCRIPTION
## Summary
- open $EDITOR to edit flyer body text
- show live character counts for metadata and links
- allow choosing Tor vs HTTPS URL style
- mention new Python deps in README
- install Python deps from setup script

## Testing
- `python3 -m py_compile voxvera/*.py`

------
https://chatgpt.com/codex/tasks/task_b_68542e75f614832b8e902cca29210fd4