### PR TITLE
Add GUI and packaging helpers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,11 @@ jobs:
         run: python -m build --wheel --sdist
       - name: Build binary
         run: pyinstaller --onefile -n voxvera voxvera/cli.py
+      - name: Create AppImage
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wget
+          bash packaging/build_appimage.sh
       - name: Build Docker image
         run: docker build -t ghcr.io/${{ github.repository_owner }}/voxvera:${{ github.ref_name }} .
       - name: Login to GHCR
@@ -42,3 +47,4 @@ jobs:
             dist/*.whl
             dist/*.tar.gz
             dist/voxvera
+            dist/VoxVera.AppImage

--- a/README.md
+++ b/README.md
@@ -17,6 +17,16 @@ See [docs/usage.md](docs/usage.md) for detailed usage instructions.
 
 Run the installer to set up all dependencies and the `voxvera` CLI in one step.
 
+### GUI
+An Electron wrapper is provided under `gui/electron` for users that prefer a graphical interface.
+Run it with:
+
+```bash
+cd gui/electron
+npm install
+npm start
+```
+
 ### Linux/macOS
 
 ```bash
@@ -115,6 +125,12 @@ The script updates the chosen config file, regenerates QR codes, obfuscates `ind
 Additional documentation is available in the `src/` directory; see [src/README.md](src/README.md) for more details on the obfuscation scripts and additional usage notes.
 
 Additional documentation, including step-by-step instructions and hosting guides, lives under the [docs](docs/) directory.
+
+## Packages
+Prebuilt binaries are published on the releases page. Linux users can run the
+`packaging/build_appimage.sh` script after a PyInstaller build to create a
+portable AppImage. Homebrew and Chocolatey formulas are provided under
+`packaging/` for easy upgrades on macOS and Windows.
 
 
 This project is licensed under the [MIT License](./LICENSE).

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,0 +1,16 @@
+# VoxVera GUI
+
+This directory contains a minimal Electron wrapper around the `voxvera` CLI.
+It exposes a simple "Quickstart" button so non-technical users can generate
+flyers without touching the command line.
+
+## Development
+
+```
+cd gui/electron
+npm install
+npm start
+```
+
+The Electron app invokes the `voxvera` binary from your `PATH`.
+Make sure it is installed before launching the GUI.

--- a/gui/electron/index.html
+++ b/gui/electron/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>VoxVera GUI</title>
+</head>
+<body>
+  <h1>VoxVera</h1>
+  <button id="quickstart">Quickstart</button>
+  <script>
+    document.getElementById('quickstart').addEventListener('click', () => {
+      window.voxvera.quickstart();
+    });
+  </script>
+</body>
+</html>

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -1,0 +1,28 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const { spawn } = require('child_process');
+const path = require('path');
+
+function createWindow() {
+  const win = new BrowserWindow({
+    width: 800,
+    height: 600,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js')
+    }
+  });
+  win.loadFile('index.html');
+}
+
+app.whenReady().then(createWindow);
+
+ipcMain.handle('run-quickstart', async () => {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('voxvera', ['quickstart'], { stdio: 'inherit' });
+    proc.on('close', code => resolve(code));
+    proc.on('error', err => reject(err));
+  });
+});
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/gui/electron/package.json
+++ b/gui/electron/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "voxvera-gui",
+  "version": "0.1.0",
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^29.0.0"
+  }
+}

--- a/gui/electron/preload.js
+++ b/gui/electron/preload.js
@@ -1,0 +1,5 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+contextBridge.exposeInMainWorld('voxvera', {
+  quickstart: () => ipcRenderer.invoke('run-quickstart')
+});

--- a/packaging/build_appimage.sh
+++ b/packaging/build_appimage.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -e
+
+if [ ! -f dist/voxvera ]; then
+  echo "Run PyInstaller first" >&2
+  exit 1
+fi
+
+APPDIR=dist/AppDir
+mkdir -p "$APPDIR/usr/bin"
+cp dist/voxvera "$APPDIR/usr/bin/voxvera"
+chmod +x "$APPDIR/usr/bin/voxvera"
+
+cat > "$APPDIR/voxvera.desktop" <<EOD
+[Desktop Entry]
+Type=Application
+Name=VoxVera
+Exec=voxvera
+Icon=voxvera
+Categories=Utility;
+EOD
+
+touch "$APPDIR/voxvera.png"
+
+wget -q https://github.com/AppImage/AppImageKit/releases/latest/download/appimagetool-x86_64.AppImage -O appimagetool
+chmod +x appimagetool
+./appimagetool "$APPDIR" dist/VoxVera.AppImage
+rm appimagetool
+
+echo "AppImage created at dist/VoxVera.AppImage"

--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -1,0 +1,12 @@
+$toolsDir   = Split-Path -Parent $MyInvocation.MyCommand.Definition
+$url        = 'https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera.exe'
+
+$packageArgs = @{
+  packageName    = 'voxvera'
+  fileType       = 'exe'
+  url            = $url
+  silentArgs     = '/S'
+  validExitCodes = @(0)
+}
+
+Install-ChocolateyPackage @packageArgs

--- a/packaging/chocolatey/voxvera.nuspec
+++ b/packaging/chocolatey/voxvera.nuspec
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<package>
+  <metadata>
+    <id>voxvera</id>
+    <version>0.1.0</version>
+    <title>VoxVera</title>
+    <authors>VoxVera</authors>
+    <description>Generate flyers with QR codes</description>
+    <projectUrl>https://github.com/PR0M3TH3AN/VoxVera</projectUrl>
+    <tags>voxvera flyers</tags>
+  </metadata>
+</package>

--- a/packaging/homebrew/voxvera.rb
+++ b/packaging/homebrew/voxvera.rb
@@ -1,0 +1,15 @@
+class Voxvera < Formula
+  desc "Generate QR-coded flyers"
+  homepage "https://github.com/PR0M3TH3AN/VoxVera"
+  url "https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera"
+  version "0.1.0"
+  sha256 "<insert-sha256>"
+
+  def install
+    bin.install "voxvera"
+  end
+
+  test do
+    system "#{bin}/voxvera", "--help"
+  end
+end


### PR DESCRIPTION
## Summary
- add an Electron wrapper under `gui/`
- include build step for AppImage in release workflow
- provide Homebrew and Chocolatey package definitions
- document GUI and package usage in README

## Testing
- `flake8 voxvera tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685433d9804c832bb8b215d2cfd53d37