### PR TITLE
Add E2E workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,25 @@
+name: E2E
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y tor qrencode imagemagick jq python3-pip
+          pip install onionshare-cli==2.*
+      - name: Run end-to-end tests
+        run: ci/test-e2e.sh
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: ci-logs
+          path: ci-logs/


### PR DESCRIPTION
## Summary
- add `e2e.yml` workflow to test install and OnionShare integration

## Testing
- `flake8 voxvera tests`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_6854470c4574832ba5854a7969c6994c