### PR TITLE
Improve Electron GUI error handling

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -15,3 +15,6 @@ This page collects common issues encountered when hosting or accessing flyers.
 - Run `sudo chcon -Rt svirt_sandbox_file_t host` or disable SELinux enforcement for the folder.
 
 If problems persist, consult the OnionShare and Tor documentation for more advanced configuration tips.
+
+## Electron GUI
+If `npm start` fails with `spawn voxvera ENOENT`, the `voxvera` command is not in your `PATH`. Install it with `pipx install voxvera` or run `./install.sh` from the repository.

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -1,6 +1,7 @@
-const { app, BrowserWindow, ipcMain } = require('electron');
+const { app, BrowserWindow, ipcMain, dialog } = require('electron');
 const { spawn } = require('child_process');
 const path = require('path');
+const which = require('which');
 
 function createWindow() {
   const win = new BrowserWindow({
@@ -16,8 +17,16 @@ function createWindow() {
 app.whenReady().then(createWindow);
 
 ipcMain.handle('run-quickstart', async () => {
+  const voxveraPath = which.sync('voxvera', { nothrow: true });
+  if (!voxveraPath) {
+    dialog.showErrorBox(
+      'voxvera not found',
+      'Install the voxvera CLI and ensure it is in your PATH.'
+    );
+    return -1;
+  }
   return new Promise((resolve, reject) => {
-    const proc = spawn('voxvera', ['quickstart'], { stdio: 'inherit' });
+    const proc = spawn(voxveraPath, ['quickstart'], { stdio: 'inherit' });
     proc.on('close', code => resolve(code));
     proc.on('error', err => reject(err));
   });

--- a/gui/electron/package.json
+++ b/gui/electron/package.json
@@ -6,6 +6,7 @@
     "start": "electron ."
   },
   "devDependencies": {
-    "electron": "^29.0.0"
+    "electron": "^29.0.0",
+    "which": "^3.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- warn users when the `voxvera` CLI isn't in PATH
- mention this failure mode in troubleshooting guide
- require `which` npm module

## Testing
- `flake8`
- `pytest -q`
- `npm install` in `gui/electron`

------
https://chatgpt.com/codex/tasks/task_b_68547119f1a0832bb2ae31d12793a1f0