### PR TITLE
Fix CI e2e script

### DIFF
--- a/ci/test-e2e.sh
+++ b/ci/test-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -euo pipefail
 
 LOG_DIR="$(pwd)/ci-logs"


### PR DESCRIPTION
## Summary
- ensure `ci/test-e2e.sh` runs under bash so `pipefail` works

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854814fcd40832b977cc8926aeceed6