### PR TITLE
Fix e2e test script shebang

### DIFF
--- a/ci/test-e2e.sh
+++ b/ci/test-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 set -euo pipefail
 
 LOG_DIR="$(pwd)/ci-logs"


### PR DESCRIPTION
## Summary
- make `ci/test-e2e.sh` use bash so `pipefail` works

## Testing
- `flake8`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'InquirerPy')*

------
https://chatgpt.com/codex/tasks/task_b_685481649254832bbaabbb9026ade402