### PR TITLE
Add fallback on pipx failure

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -24,7 +24,15 @@ if ($choco) {
 }
 
 if (Get-Command pipx -ErrorAction SilentlyContinue) {
-    pipx install voxvera --force
+    try {
+        pipx install voxvera --force
+    } catch {
+        Write-Host 'pipx install failed, downloading binary'
+        $dest = "$HOME/.local/bin"
+        New-Item -ItemType Directory -Path $dest -Force | Out-Null
+        $url = 'https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera.exe'
+        Invoke-WebRequest -Uri $url -OutFile "$dest/voxvera.exe"
+    }
 } else {
     $dest = "$HOME/.local/bin"
     New-Item -ItemType Directory -Path $dest -Force | Out-Null

--- a/install.sh
+++ b/install.sh
@@ -62,7 +62,22 @@ require_pkg qrencode qrencode
 require_pkg convert imagemagick
 
 if command_exists pipx; then
-  pipx install --force voxvera
+  if ! pipx install --force voxvera; then
+    echo "pipx install failed, downloading binary"
+    install_dir="$HOME/.local/bin"
+    mkdir -p "$install_dir"
+    url="https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera"
+    dest="$install_dir/voxvera"
+    if command_exists curl; then
+      curl -fsSL "$url" -o "$dest"
+    elif command_exists wget; then
+      wget -q "$url" -O "$dest"
+    else
+      echo "Install curl or wget to download voxvera" >&2
+      exit 1
+    fi
+    chmod +x "$dest"
+  fi
 else
   install_dir="$HOME/.local/bin"
   mkdir -p "$install_dir"


### PR DESCRIPTION
## Summary
- auto-download voxvera binary if `pipx install` fails
- same fallback for PowerShell installer
- rerun e2e workflow

## Testing
- `bash ci/test-e2e.sh` *(fails: 404 from GitHub)*

------
https://chatgpt.com/codex/tasks/task_b_68548c29d66c832bb1b00993ae1e4a37