### PR TITLE
Improve installer failure handling

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -23,6 +23,32 @@ if ($choco) {
     foreach ($p in $packages) { Install-Pkg $p }
 }
 
+function Install-PipFallback {
+    if (Get-Command pip -ErrorAction SilentlyContinue) {
+        try {
+            pip install --user voxvera
+            Write-Host 'VoxVera installed successfully via pip.'
+            exit 0
+        } catch {
+            Write-Error 'pip installation failed.'
+            exit 1
+        }
+    } else {
+        Write-Error 'pip not found for fallback installation.'
+        exit 1
+    }
+}
+
+function Download-Binary {
+    param([string]$Url, [string]$Dest)
+    try {
+        Invoke-WebRequest -Uri $Url -OutFile $Dest -ErrorAction Stop
+        return $true
+    } catch {
+        return $false
+    }
+}
+
 if (Get-Command pipx -ErrorAction SilentlyContinue) {
     try {
         pipx install voxvera --force
@@ -31,13 +57,19 @@ if (Get-Command pipx -ErrorAction SilentlyContinue) {
         $dest = "$HOME/.local/bin"
         New-Item -ItemType Directory -Path $dest -Force | Out-Null
         $url = 'https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera.exe'
-        Invoke-WebRequest -Uri $url -OutFile "$dest/voxvera.exe"
+        if (-not (Download-Binary $url "$dest/voxvera.exe")) {
+            Write-Host 'Binary download failed, falling back to pip'
+            Install-PipFallback
+        }
     }
 } else {
     $dest = "$HOME/.local/bin"
     New-Item -ItemType Directory -Path $dest -Force | Out-Null
     $url = 'https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera.exe'
-    Invoke-WebRequest -Uri $url -OutFile "$dest/voxvera.exe"
+    if (-not (Download-Binary $url "$dest/voxvera.exe")) {
+        Write-Host 'Binary download failed, falling back to pip'
+        Install-PipFallback
+    }
 }
 
 Write-Host 'VoxVera installed successfully.'


### PR DESCRIPTION
## Summary
- handle download errors in `install.sh` with fallback to `pip install`
- add equivalent fallback logic in `install.ps1`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685490d0bee0832b8d79bcc5076dbc6b