### PR TITLE
Install from source in e2e tests

### DIFF
--- a/ci/test-e2e.sh
+++ b/ci/test-e2e.sh
@@ -5,8 +5,8 @@ LOG_DIR="$(pwd)/ci-logs"
 mkdir -p "$LOG_DIR"
 exec >"$LOG_DIR/run.log" 2>&1
 
-# Run install script and time it
-{ time ./install.sh; } 2>&1
+# Install VoxVera from the local repository and time it
+{ time pip install -e .; } 2>&1
 
 # Generate demo flyer
 voxvera init --template voxvera <<EOI


### PR DESCRIPTION
## Summary
- ensure CI installs VoxVera directly from the repo for E2E

## Testing
- `pip install -e .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685491b06760832b8eb6ab1d321d872d