### PR TITLE
Update PowerShell install path handling

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -54,7 +54,8 @@ if (Get-Command pipx -ErrorAction SilentlyContinue) {
         pipx install voxvera --force
     } catch {
         Write-Host 'pipx install failed, downloading binary'
-        $dest = "$HOME/.local/bin"
+        $home = [Environment]::GetFolderPath('UserProfile')
+        $dest = Join-Path $home '.local\bin'
         New-Item -ItemType Directory -Path $dest -Force | Out-Null
         $url = 'https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera.exe'
         if (-not (Download-Binary $url "$dest/voxvera.exe")) {
@@ -63,7 +64,8 @@ if (Get-Command pipx -ErrorAction SilentlyContinue) {
         }
     }
 } else {
-    $dest = "$HOME/.local/bin"
+    $home = [Environment]::GetFolderPath('UserProfile')
+    $dest = Join-Path $home '.local\bin'
     New-Item -ItemType Directory -Path $dest -Force | Out-Null
     $url = 'https://github.com/PR0M3TH3AN/VoxVera/releases/latest/download/voxvera.exe'
     if (-not (Download-Binary $url "$dest/voxvera.exe")) {


### PR DESCRIPTION
## Summary
- ensure VoxVera installer resolves the user's profile via `[Environment]::GetFolderPath('UserProfile')`
- create `.local\bin` under this path before downloading the binary

## Testing
- `pip install -e .[test]`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68549245c264832ba7756f62f4ec67f5