### PR TITLE
Check PATH in install scripts

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -49,6 +49,14 @@ function Download-Binary {
     }
 }
 
+function Check-LocalBin {
+    $home = [Environment]::GetFolderPath('UserProfile')
+    $binPath = Join-Path $home '.local\bin'
+    if (-not ($Env:PATH.Split(';') -contains $binPath)) {
+        Write-Host "Add $binPath to your PATH to run VoxVera."
+    }
+}
+
 if (Get-Command pipx -ErrorAction SilentlyContinue) {
     try {
         pipx install voxvera --force
@@ -61,6 +69,8 @@ if (Get-Command pipx -ErrorAction SilentlyContinue) {
         if (-not (Download-Binary $url "$dest/voxvera.exe")) {
             Write-Host 'Binary download failed, falling back to pip'
             Install-PipFallback
+        } else {
+            Check-LocalBin
         }
     }
 } else {
@@ -71,6 +81,8 @@ if (Get-Command pipx -ErrorAction SilentlyContinue) {
     if (-not (Download-Binary $url "$dest/voxvera.exe")) {
         Write-Host 'Binary download failed, falling back to pip'
         Install-PipFallback
+    } else {
+        Check-LocalBin
     }
 }
 

--- a/install.sh
+++ b/install.sh
@@ -75,6 +75,12 @@ download_binary() {
   chmod +x "$dest"
 }
 
+check_local_bin() {
+  if [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    echo "Add \$HOME/.local/bin to your PATH to run VoxVera."
+  fi
+}
+
 pip_fallback() {
   if command_exists pip; then
     echo "Attempting pip install as fallback..."
@@ -99,6 +105,8 @@ if command_exists pipx; then
     if ! download_binary "$url" "$dest"; then
       echo "Binary download failed, falling back to pip." >&2
       pip_fallback
+    else
+      check_local_bin
     fi
   fi
 else
@@ -109,6 +117,8 @@ else
   if ! download_binary "$url" "$dest"; then
     echo "Binary download failed, falling back to pip." >&2
     pip_fallback
+  else
+    check_local_bin
   fi
 fi
 


### PR DESCRIPTION
## Summary
- alert users if `$HOME/.local/bin` is not on `PATH`
- ensure both install scripts check for the path after copying the VoxVera binary

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685495e37b44832b95f7533413c6a4ae