### PR TITLE
Fix setup and install fallbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ See [docs/usage.md](docs/usage.md) for detailed usage instructions.
 
 Run the installer to set up the core dependencies and install the `voxvera` CLI.
 The script installs Tor, OnionShare, `jq`, `qrencode`, and ImageMagick before
-fetching the latest release of the CLI. Other prerequisites like Node.js,
-`javascript-obfuscator`, `html-minifier-terser`, and the Python packages
-`InquirerPy` and `rich` are not installed automatically. Run `setup.sh` or
-install those packages manually if they are missing.
+fetching the latest release of the CLI. Run `setup.sh` to install additional
+dependencies such as Node.js, `javascript-obfuscator`, `html-minifier-terser`,
+and the Python packages `InquirerPy` and `rich` if they are not already
+available.
 
 If you already have the prerequisites you can install the package directly from
 PyPI:
@@ -95,14 +95,14 @@ globally:
 npm install -g javascript-obfuscator html-minifier-terser
 ```
 
-Install the Python dependencies:
+`setup.sh` also installs the required Python packages automatically. If you
+prefer to install them manually, run:
 
 ```bash
 pip install --user InquirerPy rich
 ```
 
-A helper script `setup.sh` is provided to check for these dependencies and
-install anything that is missing.
+The script checks for these dependencies and installs anything that is missing.
 
 ### Windows
 

--- a/setup.sh
+++ b/setup.sh
@@ -41,11 +41,11 @@ done
 
 # ensure Python packages used by the CLI are available
 for py in InquirerPy rich; do
-  python3 - <<EOF >/dev/null 2>&1
+  if ! python3 - <<EOF >/dev/null 2>&1
 import importlib.util, sys
 sys.exit(0 if importlib.util.find_spec('$py') else 1)
 EOF
-  if [ $? -ne 0 ]; then
+  then
     pip install --user "$py"
   fi
 done


### PR DESCRIPTION
## Summary
- avoid early exit when checking Python packages in `setup.sh`
- install from repo if binary missing in install scripts
- allow offline mode for e2e tests
- document new behaviour in README

## Testing
- `pip install -e .`
- `pytest -q`
- `shellcheck setup.sh install.sh ci/test-e2e.sh`

------
https://chatgpt.com/codex/tasks/task_b_68548fa61ccc832b8237bee46cc82e85