### PR TITLE
Run e2e tests in offline mode

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,14 +8,15 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    env:
+      VOXVERA_E2E_OFFLINE: "1"
     steps:
       - uses: actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y tor qrencode imagemagick jq python3-pip nodejs npm
+          sudo apt-get install -y qrencode imagemagick jq python3-pip nodejs npm
           npm install -g javascript-obfuscator html-minifier-terser
-          pip install onionshare-cli==2.*
       - name: Run end-to-end tests
         run: ci/test-e2e.sh
       - name: Upload logs


### PR DESCRIPTION
## Summary
- disable network dependent steps for e2e workflow
- stop installing Tor and OnionShare in CI

## Testing
- `flake8 voxvera tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854ab18c978832baed932e6c881bda0