### PR TITLE
Add CLI integration tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,13 +1,66 @@
 
-import os, sys
+import os
+import sys
+import shutil
+import json
+import datetime
+from pathlib import Path
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from voxvera.cli import main
 import pytest
+from voxvera import cli
+
+
+def _setup_tmp(monkeypatch, tmp_path):
+    repo_root = Path(__file__).resolve().parent.parent
+    shutil.copytree(repo_root / "src", tmp_path / "src")
+    monkeypatch.setattr(cli, "ROOT", tmp_path)
+    monkeypatch.setattr(cli, "_src_res", lambda *p: tmp_path / "src" / Path(*p))
+    monkeypatch.setattr(cli, "run", lambda *a, **k: None)
+    return repo_root
+
 
 
 def test_help(capsys):
     with pytest.raises(SystemExit):
-        main(["-h"])
+        cli.main(["-h"])
     captured = capsys.readouterr()
     assert "usage:" in captured.out
+
+
+def test_init_template(tmp_path, monkeypatch):
+    _setup_tmp(monkeypatch, tmp_path)
+    cli.main(["init", "--template", "voxvera"])
+    date = datetime.date.today().strftime("%Y%m%d")
+    dest = tmp_path / "dist" / f"voxvera-{date}"
+    assert dest.is_dir()
+    assert (dest / "config.json").exists()
+    assert (dest / "index.html").exists()
+
+
+def test_build(tmp_path, monkeypatch):
+    _setup_tmp(monkeypatch, tmp_path)
+    cli.main(["build"])
+    dest = tmp_path / "host" / "voxvera"
+    assert dest.is_dir()
+    assert (dest / "config.json").exists()
+    assert (dest / "index.html").exists()
+
+
+def test_import(tmp_path, monkeypatch):
+    repo = _setup_tmp(monkeypatch, tmp_path)
+    imports_dir = tmp_path / "imports"
+    imports_dir.mkdir()
+    base_data = json.load(open(repo / "imports" / "example.json"))
+    for sub in ["foo", "bar"]:
+        data = dict(base_data)
+        data["subdomain"] = sub
+        with open(imports_dir / f"{sub}.json", "w") as fh:
+            json.dump(data, fh)
+    cli.main(["import"])
+    for sub in ["foo", "bar"]:
+        dest = tmp_path / "host" / sub
+        assert dest.is_dir()
+        assert (dest / "index.html").exists()
+


### PR DESCRIPTION
## Summary
- test help output
- test `init --template` copies expected files to `dist/`
- test `build` writes flyer assets into `host/`
- test `import` processes JSON files and writes to `host/`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6854b386c4a4832b80055f2a563a00e3