### PR TITLE
Add download option to build command

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -48,6 +48,15 @@ def test_build(tmp_path, monkeypatch):
     assert (dest / "index.html").exists()
 
 
+def test_build_with_download(tmp_path, monkeypatch):
+    _setup_tmp(monkeypatch, tmp_path)
+    download_file = tmp_path / "sample.zip"
+    download_file.write_text("dummy")
+    cli.main(["build", "--download", str(download_file)])
+    dest = tmp_path / "host" / "voxvera" / "download" / "download.zip"
+    assert dest.is_file()
+
+
 def test_import(tmp_path, monkeypatch):
     repo = _setup_tmp(monkeypatch, tmp_path)
     imports_dir = tmp_path / "imports"

--- a/voxvera/cli.py
+++ b/voxvera/cli.py
@@ -263,7 +263,8 @@ def copy_template(name: str) -> str:
     return str(dest)
 
 
-def build_assets(config_path: str, pdf_path: str | None = None):
+def build_assets(config_path: str, pdf_path: str | None = None,
+                 download_path: str | None = None):
     with resources.as_file(_src_res()) as src_dir:
         # generate QR codes
         run(['bash', 'generate_qr.sh', config_path], cwd=src_dir)
@@ -281,6 +282,9 @@ def build_assets(config_path: str, pdf_path: str | None = None):
         subdomain = data['subdomain']
         dest = ROOT / 'host' / subdomain
         os.makedirs(dest / 'from_client', exist_ok=True)
+        if download_path:
+            os.makedirs(dest / 'download', exist_ok=True)
+            shutil.copy(download_path, dest / 'download' / 'download.zip')
         shutil.copy(config_path, dest / 'config.json')
         for fname in ['index.html', 'nostr.html', 'qrcode-content.png', 'qrcode-tear-offs.png', 'example.pdf', 'submission_form.pdf']:
             shutil.copy(src_dir / fname, dest)
@@ -356,6 +360,7 @@ def main(argv=None):
 
     p_build = sub.add_parser('build', help='Build flyer assets from config')
     p_build.add_argument('--pdf')
+    p_build.add_argument('--download')
 
     sub.add_parser('import', help='Batch import JSON files from imports/')
     sub.add_parser('serve', help='Serve flyer over OnionShare using config')
@@ -376,7 +381,7 @@ def main(argv=None):
         elif not args.non_interactive:
             interactive_update(config_path)
     elif args.command == 'build':
-        build_assets(config_path, pdf_path=args.pdf)
+        build_assets(config_path, pdf_path=args.pdf, download_path=args.download)
     elif args.command == 'serve':
         serve(config_path)
     elif args.command == 'import':


### PR DESCRIPTION
## Summary
- allow `build_assets()` to copy an optional download archive
- expose `--download` option in CLI build command
- test new option

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856caa25230832b83b89ffbbb7f1f6e