### PR TITLE
Update docs for zip download option

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,16 @@ voxvera init --config path/to/custom.json
 voxvera init --from-pdf path/to/form.pdf
 ```
 
+After updating the configuration run the build step. You can optionally
+include a zip file that visitors can download:
+
+```bash
+voxvera build --download path/to/file.zip
+```
+
+If `--download` is omitted the CLI looks for `src/download/download.zip` and
+copies it into the output directory.
+
 When run interactively you'll be prompted for details such as the flyer title
 and headline. The script now also asks for a **URL** and a **Tear-off link**.
 These values are written into the configuration file (`src/config.json` by

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,7 +5,11 @@ This guide covers common CLI workflows. See `docs/docker.md` for Docker instruct
 ## Step-by-Step
 1. Edit `src/index-master.html` or `src/nostr-master.html` if you need custom content.
 2. Run `voxvera init` and follow the prompts, or use `voxvera init --from-pdf path/to/form.pdf`.
-3. Host the generated `host/<subdomain>` directory. The `index.html` file fetches `config.json`, so the flyer must be served via a local or remote web server rather than opened directly from disk. For a quick test you can run `python3 -m http.server` inside the folder and then visit the provided address.
+3. Build the flyer assets. Add an optional zip file at `src/download/download.zip` or pass `--download` to include it in the build:
+   ```bash
+   voxvera build --download path/to/file.zip
+   ```
+4. Host the generated `host/<subdomain>` directory. The `index.html` file fetches `config.json`, so the flyer must be served via a local or remote web server rather than opened directly from disk. For a quick test you can run `python3 -m http.server` inside the folder and then visit the provided address. Visitors can use the **Download** button to retrieve the file.
 
 ## Batch Import
 Place configuration files in an `imports/` directory at the project root and run:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,6 @@ def _setup_tmp(monkeypatch, tmp_path):
     return repo_root
 
 
-
 def test_help(capsys):
     with pytest.raises(SystemExit):
         cli.main(["-h"])
@@ -102,4 +101,3 @@ def test_build_download_zip(tmp_path, monkeypatch):
     cli.main(["build", "--download", str(zip_path)])
     dest = tmp_path / "host" / subdomain / "download" / "download.zip"
     assert dest.is_file()
-


### PR DESCRIPTION
## Summary
- document `--download` option in README and usage guide
- mention default `src/download/download.zip` location
- fix minor flake8 warnings in tests

## Testing
- `flake8 voxvera tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856cc568f24832bad7d6c48e6bae317