### PR TITLE
Add download folder to voxvera template

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,6 +37,8 @@ def test_init_template(tmp_path, monkeypatch):
     assert dest.is_dir()
     assert (dest / "config.json").exists()
     assert (dest / "index.html").exists()
+    # new download directory should be copied as well
+    assert (dest / "download").is_dir()
 
 
 def test_build(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add an empty `download/` folder in `templates/voxvera`
- assert presence of `download/` directory when initializing template

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856cd97c5b8832ba3ced8e215376396