### PR TITLE
Fix deprecated Traversable import

### DIFF
--- a/voxvera/cli.py
+++ b/voxvera/cli.py
@@ -8,7 +8,7 @@ import sys
 import datetime
 from pathlib import Path
 from importlib import resources
-from importlib.abc import Traversable
+from importlib.resources.abc import Traversable
 from InquirerPy import prompt, inquirer
 from rich.console import Console
 


### PR DESCRIPTION
## Summary
- silence deprecation warnings by using `importlib.resources.abc.Traversable`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856d8e264b4832b8cfe4709ab72e629