### PR TITLE
Add cleanup traps to shell scripts

### DIFF
--- a/voxvera/src/generate_qr.sh
+++ b/voxvera/src/generate_qr.sh
@@ -18,12 +18,16 @@ tear=$(jq -r '.tear_off_link' "$CONFIG")
 tmp_content=$(mktemp)
 tmp_tear=$(mktemp)
 
+cleanup() {
+  rm -f "$tmp_content" "$tmp_tear"
+}
+
+trap cleanup EXIT
+
 qrencode -o "$tmp_content" -s 10 -m 0 "$url"
 qrencode -o "$tmp_tear" -s 10 -m 0 "$tear"
 
 convert "$tmp_content" -resize 128x128 "qrcode-content.png"
 convert "$tmp_tear" -resize 128x128 "qrcode-tear-offs.png"
-
-rm -f "$tmp_content" "$tmp_tear"
 
 echo "QR codes generated"

--- a/voxvera/src/obfuscate_index.sh
+++ b/voxvera/src/obfuscate_index.sh
@@ -31,6 +31,12 @@ temp_js_file=$(mktemp_with_suffix .js)  # Temporary .js file for extracting Java
 temp_js_obfuscated_file=$(mktemp_with_suffix .js)  # Temporary file for obfuscated JavaScript
 temp_html_file=$(mktemp)  # Temporary file for processing HTML without JS
 
+cleanup() {
+  rm -f "$temp_js_file" "$temp_js_obfuscated_file" "$temp_html_file"
+}
+
+trap cleanup EXIT
+
 # Check if the input file exists
 if [ ! -f "$input_file" ]; then
     echo "Input file $input_file does not exist."
@@ -61,7 +67,6 @@ html-minifier-terser \
     --output "$output_file" \
     "$temp_html_file"
 
-# Clean up temporary files
-rm "$temp_js_file" "$temp_js_obfuscated_file" "$temp_html_file"
+# Clean up temporary files handled by trap
 
 echo "Obfuscation and minification complete. Output saved as $output_file."

--- a/voxvera/src/obfuscate_nostr.sh
+++ b/voxvera/src/obfuscate_nostr.sh
@@ -31,6 +31,12 @@ temp_js_file=$(mktemp_with_suffix .js)  # Temporary .js file for extracting Java
 temp_js_obfuscated_file=$(mktemp_with_suffix .js)  # Temporary file for obfuscated JavaScript
 temp_html_file=$(mktemp)  # Temporary file for processing HTML without JS
 
+cleanup() {
+  rm -f "$temp_js_file" "$temp_js_obfuscated_file" "$temp_html_file"
+}
+
+trap cleanup EXIT
+
 # Check if the input file exists
 if [ ! -f "$input_file" ]; then
     echo "Input file $input_file does not exist."
@@ -61,7 +67,6 @@ html-minifier-terser \
     --output "$output_file" \
     "$temp_html_file"
 
-# Clean up temporary files
-rm "$temp_js_file" "$temp_js_obfuscated_file" "$temp_html_file"
+# Clean up temporary files handled by trap
 
 echo "Obfuscation and minification complete. Output saved as $output_file."


### PR DESCRIPTION
## Summary
- add cleanup traps to generate_qr.sh to avoid leftover tmp files
- add cleanup traps to obfuscate_index.sh and obfuscate_nostr.sh
- keep tests green

## Testing
- `pytest -q`
- `bash generate_qr.sh config.json`
- `bash obfuscate_index.sh`
- `bash obfuscate_nostr.sh`


------
https://chatgpt.com/codex/tasks/task_b_6856dc017b54832bb8da3c41d90e6ec7