### PR TITLE
Update README with venv instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ pipx install voxvera  # recommended
 pip install --user voxvera
 ```
 
+If your system reports an "externally-managed" Python environment and blocks installation, create a virtual environment first:
+
+```bash
+python3 -m venv voxvera-venv
+source voxvera-venv/bin/activate
+pip install voxvera
+```
+
 The legacy `src/create_flyer.sh` script remains for backward compatibility. It
 simply forwards its arguments to the Python CLI so existing workflows continue
 to work.


### PR DESCRIPTION
## Summary
- document installing VoxVera in a Python virtual environment

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856ea79c320832b871cf96a5036b46c