### PR TITLE
Fix GUI quickstart config path

### DIFF
--- a/voxvera/cli.py
+++ b/voxvera/cli.py
@@ -12,8 +12,8 @@ from importlib.resources.abc import Traversable
 from InquirerPy import prompt, inquirer
 from rich.console import Console
 
-# project root
-ROOT = Path(__file__).resolve().parent.parent
+# package root (contains bundled templates and src/)
+ROOT = Path(__file__).resolve().parent
 
 
 def _template_res(*parts) -> Traversable:


### PR DESCRIPTION
## Summary
- fix ROOT path in `voxvera.cli`

## Testing
- `pytest -q`
- `python -m voxvera.cli --config voxvera/src/config.json check | head`

------
https://chatgpt.com/codex/tasks/task_b_6856f72bdc68832bb722bf7aa7416cd4