### PR TITLE
Display onion address in Electron GUI

### DIFF
--- a/gui/electron/index.html
+++ b/gui/electron/index.html
@@ -7,9 +7,13 @@
 <body>
   <h1>VoxVera</h1>
   <button id="quickstart">Quickstart</button>
+  <p id="onion-address"></p>
   <script>
     document.getElementById('quickstart').addEventListener('click', () => {
       window.voxvera.quickstart();
+    });
+    window.voxvera.onOnionUrl(url => {
+      document.getElementById('onion-address').textContent = `Onion address: ${url}`;
     });
   </script>
 </body>

--- a/gui/electron/preload.js
+++ b/gui/electron/preload.js
@@ -1,5 +1,6 @@
 const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('voxvera', {
-  quickstart: () => ipcRenderer.invoke('run-quickstart')
+  quickstart: () => ipcRenderer.invoke('run-quickstart'),
+  onOnionUrl: (cb) => ipcRenderer.on('onion-url', (_, url) => cb(url))
 });


### PR DESCRIPTION
## Summary
- emit onion URL from the `voxvera` quickstart process
- expose an event in the preload script and display the address in the GUI

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6856f9a8e1d8832bb5ec00796451e6ca