### PR TITLE
Add Tkinter editor for text fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Generate printable flyers with QR codes linking to Tor (.onion) or HTTPS sites, 
 
 ## 🚀 Key Features
 
-* **Interactive setup**: `voxvera init` prompts for metadata or extracts from a PDF form.
+* **Interactive setup**: `voxvera init` prompts for metadata or extracts from a PDF form. When editing body text, a simple GUI window opens with existing content pre-filled.
 * **Template support**: `voxvera init --template <name>` copies built‑in templates (`blank`, `voxvera`).
 * **Build assets**: `voxvera build [--pdf <path>] [--download <file.zip>]` generates HTML, obfuscated JS/CSS, QR codes, and bundles PDFs.
 * **Batch import**: `voxvera import` processes all JSON configs in `imports/`.


### PR DESCRIPTION
## Summary
- open a Tkinter GUI when editing flyer text
- document GUI text editing in README

## Testing
- `flake8 voxvera tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6856fc37cf48832bb0daf818ad9a70cb