### PR TITLE
Improve GUI error feedback

### DIFF
--- a/gui/electron/index.html
+++ b/gui/electron/index.html
@@ -3,6 +3,16 @@
 <head>
   <meta charset="UTF-8">
   <title>VoxVera GUI</title>
+  <style>
+    #log {
+      border: 1px solid #ccc;
+      padding: 5px;
+      height: 150px;
+      overflow-y: auto;
+      background: #f8f8f8;
+      white-space: pre-wrap;
+    }
+  </style>
 </head>
 <body>
   <h1>VoxVera</h1>
@@ -20,6 +30,7 @@
     <button type="button" id="quickstart">Generate &amp; Serve</button>
   </form>
   <p id="onion-address"></p>
+  <pre id="log"></pre>
   <script>
     async function load() {
       const cfg = await window.voxvera.loadConfig();
@@ -42,6 +53,15 @@
 
     window.voxvera.onOnionUrl(url => {
       document.getElementById('onion-address').textContent = `Onion address: ${url}`;
+    });
+
+    window.voxvera.onLog((msg, isErr) => {
+      const container = document.getElementById('log');
+      const span = document.createElement('span');
+      if (isErr) span.style.color = 'red';
+      span.textContent = msg;
+      container.appendChild(span);
+      container.scrollTop = container.scrollHeight;
     });
   </script>
 </body>

--- a/gui/electron/preload.js
+++ b/gui/electron/preload.js
@@ -3,5 +3,6 @@ const { contextBridge, ipcRenderer } = require('electron');
 contextBridge.exposeInMainWorld('voxvera', {
   loadConfig: () => ipcRenderer.invoke('load-config'),
   quickstart: (config) => ipcRenderer.invoke('run-quickstart', config),
-  onOnionUrl: (cb) => ipcRenderer.on('onion-url', (_, url) => cb(url))
+  onOnionUrl: (cb) => ipcRenderer.on('onion-url', (_, url) => cb(url)),
+  onLog: (cb) => ipcRenderer.on('log', (_, data) => cb(data.text, data.isError))
 });

--- a/voxvera/cli.py
+++ b/voxvera/cli.py
@@ -406,7 +406,9 @@ def main(argv=None):
 
     sub.add_parser('import', help='Batch import JSON files from imports/')
     sub.add_parser('serve', help='Serve flyer over OnionShare using config')
-    sub.add_parser('quickstart', help='Init, build and serve in sequence')
+    p_quickstart = sub.add_parser('quickstart', help='Init, build and serve in sequence')
+    p_quickstart.add_argument('--non-interactive', action='store_true',
+                              help='Skip interactive prompts and use existing config')
     sub.add_parser('check', help='Check for required external dependencies')
 
     args = parser.parse_args(argv)
@@ -429,7 +431,15 @@ def main(argv=None):
     elif args.command == 'import':
         import_configs()
     elif args.command == 'quickstart':
-        interactive_update(config_path)
+        if not args.non_interactive:
+            if not sys.stdin.isatty():
+                print(
+                    "Error: quickstart requires an interactive terminal. "
+                    "Use --non-interactive or run 'voxvera init' first.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            interactive_update(config_path)
         build_assets(config_path)
         serve(config_path)
     elif args.command == 'check':


### PR DESCRIPTION
## Summary
- add `--non-interactive` flag to `quickstart` command
- prevent running interactive prompts when GUI spawns voxvera
- pipe voxvera output back to Electron renderer for display
- show logs inside a new GUI panel so errors aren't lost

## Testing
- `flake8 voxvera tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685702b2a024832b85e20465992882ea