### PR TITLE
Show OnionShare log path on failure

### DIFF
--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -72,7 +72,27 @@ function runServe(retry = false) {
   });
   onionProc.on('close', code => {
     if ((code !== 0 && code !== null) || retry) {
-      dialog.showErrorBox('OnionShare error', `onionshare exited with code ${code}.`);
+      let extra = '';
+      try {
+        const confRaw = fs.readFileSync(configPath, 'utf8');
+        const conf = JSON.parse(confRaw);
+        const logPath = path.join(
+          __dirname,
+          '..',
+          '..',
+          'host',
+          conf.subdomain,
+          'onionshare.log'
+        );
+        fs.readFileSync(logPath, 'utf8');
+        extra = `\nSee ${logPath} for details.`;
+      } catch (err) {
+        // ignore errors reading log
+      }
+      dialog.showErrorBox(
+        'OnionShare error',
+        `onionshare exited with code ${code}.${extra}`
+      );
     }
     if (!restarting && (code !== 0 || code === null)) {
       restarting = true;


### PR DESCRIPTION
## Summary
- improve GUI runServe() error handling
- show OnionShare log path when serve fails

## Testing
- `flake8 voxvera tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685712509cac832ba2e4c42ed6dfc919