### PR TITLE
Store GUI config in user data folder

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -14,3 +14,8 @@ npm start
 
 The Electron app invokes the `voxvera` binary from your `PATH`.
 Make sure it is installed before launching the GUI.
+
+Configuration is stored in your operating system's *user data* directory.
+On Linux this defaults to `~/.config/voxvera-gui/config.json`. The first
+launch copies a default `config.json` there and subsequent edits via the GUI
+update that file.

--- a/gui/electron/main.js
+++ b/gui/electron/main.js
@@ -82,7 +82,18 @@ app.whenReady().then(() => {
 });
 
 function getConfigPath() {
-  return path.join(__dirname, '..', '..', 'voxvera', 'src', 'config.json');
+  const userDir = app.getPath('userData');
+  const cfgPath = path.join(userDir, 'config.json');
+  if (!fs.existsSync(cfgPath)) {
+    try {
+      fs.mkdirSync(userDir, { recursive: true });
+      const defaultCfg = path.join(__dirname, '..', '..', 'voxvera', 'src', 'config.json');
+      fs.copyFileSync(defaultCfg, cfgPath);
+    } catch (err) {
+      dialog.showErrorBox('Config error', err.message);
+    }
+  }
+  return cfgPath;
 }
 
 ipcMain.handle('load-config', async () => {


### PR DESCRIPTION
## Summary
- copy default config into Electron's `app.getPath('userData')` folder and use it for reads/writes
- explain the new location in `gui/README.md`

## Testing
- `pip install -q InquirerPy rich`
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68571f0b52e4832b8d93b5853cb1f7ae