### PR TITLE
Update Tor path in GUI

### DIFF
--- a/gui/electron/tor.js
+++ b/gui/electron/tor.js
@@ -5,9 +5,10 @@ const getPort = require('get-port');
 async function launchTor() {
   const socks = await getPort();
   const control = await getPort();
-  const exe = path.join(__dirname, 'resources', 'tor', process.platform,
+  const torBase = path.join(__dirname, '..', '..', 'voxvera', 'resources', 'tor');
+  const exe = path.join(torBase, process.platform,
                         process.platform === 'win32' ? 'tor.exe' : 'tor');
-  const obfs4 = path.join(__dirname, 'resources', 'tor', process.platform,
+  const obfs4 = path.join(torBase, process.platform,
                          process.platform === 'win32' ? 'obfs4proxy.exe' : 'obfs4proxy');
 
   const args = [

--- a/packaging/build_appimage.sh
+++ b/packaging/build_appimage.sh
@@ -12,6 +12,9 @@ cp dist/voxvera "$APPDIR/usr/bin/voxvera"
 chmod +x "$APPDIR/usr/bin/voxvera"
 mkdir -p "$APPDIR/usr/lib/voxvera/resources"
 cp -r voxvera/resources/tor "$APPDIR/usr/lib/voxvera/resources/"
+# also bundle Tor for the Electron GUI
+mkdir -p gui/electron/voxvera/resources
+cp -r voxvera/resources/tor gui/electron/voxvera/resources/
 
 cat > "$APPDIR/voxvera.desktop" <<EOD
 [Desktop Entry]


### PR DESCRIPTION
## Summary
- look up embedded Tor binaries from `voxvera/resources/tor`
- copy Tor binaries into the Electron bundle when building the AppImage

## Testing
- `npm run lint`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68571fe29f6c832b9cce3c0e35b4e9b8