### PR TITLE
Fix ES module import for get-port

### DIFF
--- a/gui/electron/.npmrc
+++ b/gui/electron/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/gui/electron/tor.js
+++ b/gui/electron/tor.js
@@ -1,6 +1,6 @@
 const { spawn } = require('child_process');
 const path = require('path');
-const getPort = require('get-port');
+const getPort = (...args) => import('get-port').then(m => m.default(...args));
 
 async function launchTor() {
   const socks = await getPort();


### PR DESCRIPTION
## Summary
- adjust `tor.js` to dynamically import `get-port`
- lock npm versions in the Electron directory

## Testing
- `npm --prefix gui/electron install`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68573840d7bc832b88de2afd45e74fef