### PR TITLE
Fix OnionShare session arg

### DIFF
--- a/ci/test-e2e.sh
+++ b/ci/test-e2e.sh
@@ -30,7 +30,9 @@ if [ "${VOXVERA_E2E_OFFLINE:-}" != "1" ]; then
   sleep 10
 
   # Start OnionShare
-  onionshare-cli --website --public --persistent dist/demosite >"$LOG_DIR/onionshare.log" 2>&1 &
+  onionshare-cli --website --public \
+    --persistent ci/.onionshare-session \
+    dist/demosite >"$LOG_DIR/onionshare.log" 2>&1 &
   OS_PID=$!
 
 # Wait for URL

--- a/voxvera/cli.py
+++ b/voxvera/cli.py
@@ -346,7 +346,8 @@ def serve(config_path: str):
     logfile = dir_path / 'onionshare.log'
 
     cmd = [
-        'onionshare-cli', '--website', '--public', '--persistent',
+        'onionshare-cli', '--website', '--public',
+        '--persistent', str(dir_path / '.onionshare-session'),
         '--external-tor-socks-port', socks,
         '--external-tor-control-port', ctl,
         str(dir_path)


### PR DESCRIPTION
## Summary
- pass session filename to `onionshare-cli` from the voxvera CLI
- update CI to use new `--persistent` syntax

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685741dd15fc832ba12a74d4d61913f1