### PR TITLE
Remove outdated OnionShare flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ After installing either way, set the ports used by Tor:
 export TOR_SOCKS_PORT=9050
 export TOR_CONTROL_PORT=9051
 ```
-Run `voxvera check` to confirm the binaries are detected before launching.
+These variables let OnionShare connect to the already running Tor using its
+`--use-running-tor` option. Run `voxvera check` to confirm the binaries are
+detected before launching.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -11,8 +11,9 @@ This page collects common issues encountered when hosting or accessing flyers.
 The files in `voxvera/resources/tor/*` are not real executables. Install `tor`
 and `obfs4proxy` yourself (e.g. `apt install tor obfs4proxy`) then set
 `TOR_SOCKS_PORT` and `TOR_CONTROL_PORT` before running `voxvera serve` or the
-Electron GUI. Running `scripts/download_tor.sh` can also populate the missing
-files automatically.
+Electron GUI. OnionShare uses these values with its `--use-running-tor`
+argument. Running `scripts/download_tor.sh` can also populate the missing files
+automatically.
 
 ## Firewall rules
 - If `voxvera serve` fails to start OnionShare, verify that outbound connections on ports 9001 and 80 are permitted.

--- a/voxvera/cli.py
+++ b/voxvera/cli.py
@@ -348,8 +348,7 @@ def serve(config_path: str):
     cmd = [
         'onionshare-cli', '--website', '--public',
         '--persistent', str(dir_path / '.onionshare-session'),
-        '--external-tor-socks-port', socks,
-        '--external-tor-control-port', ctl,
+        '--use-running-tor',
         str(dir_path)
     ]
     proc = subprocess.Popen(cmd,


### PR DESCRIPTION
## Summary
- drop `--external-tor-*` flags in the OnionShare invocation
- document new `--use-running-tor` requirement

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68574579bf8c832b95100d8dd0a2a9e0